### PR TITLE
feat(admin): surface recent support billing activity

### DIFF
--- a/apps/web/__tests__/components/internal-support-console.test.tsx
+++ b/apps/web/__tests__/components/internal-support-console.test.tsx
@@ -76,7 +76,13 @@ function supportPayload() {
           delivery_status: "pending",
         },
       ],
-      recent_billing_events: [],
+      recent_billing_events: [
+        {
+          stripe_event_id: "evt_123",
+          event_type: "invoice.payment_failed",
+          processed_at: "2026-03-13T12:15:00Z",
+        },
+      ],
       failed_email_deliveries: [
         {
           id: "email-1",
@@ -110,7 +116,19 @@ function supportPayload() {
           created_at: "2026-03-13T12:00:00Z",
         },
       ],
-      recent_audit_logs: [],
+      recent_audit_logs: [
+        {
+          id: "audit-1",
+          org_id: "org-1",
+          actor_user_id: "user-1",
+          actor_type: "operator",
+          action: "billing.sync_requested",
+          target_type: "organization",
+          target_id: "org-1",
+          details: { source: "internal-support-console" },
+          created_at: "2026-03-13T12:20:00Z",
+        },
+      ],
     },
   };
 }
@@ -262,6 +280,10 @@ describe("InternalSupportConsole", () => {
     expect(screen.getByText("Entitlement violations")).toBeInTheDocument();
     expect(screen.getByText(/Reduce active monitors before the grace period ends/i)).toBeInTheDocument();
     expect(screen.getByText("Invitation state")).toBeInTheDocument();
+    expect(screen.getByText("Recent billing events")).toBeInTheDocument();
+    expect(screen.getByText("invoice.payment_failed")).toBeInTheDocument();
+    expect(screen.getByText("Recent audit activity")).toBeInTheDocument();
+    expect(screen.getByText("billing.sync_requested")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Sync billing" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Retry email" })).toBeInTheDocument();
   });

--- a/apps/web/components/admin/internal-support-console.tsx
+++ b/apps/web/components/admin/internal-support-console.tsx
@@ -457,6 +457,29 @@ export function InternalSupportConsole() {
               }))}
             />
           </div>
+
+          <div className="grid gap-4 xl:grid-cols-2">
+            <RecentEventsCard
+              title="Recent billing events"
+              emptyLabel="No recent billing events."
+              items={support.recent_billing_events.map((event) => ({
+                id: event.stripe_event_id,
+                title: event.event_type,
+                detail: `Stripe event ${event.stripe_event_id}`,
+                timestamp: event.processed_at,
+              }))}
+            />
+            <RecentEventsCard
+              title="Recent audit activity"
+              emptyLabel="No recent audit activity."
+              items={support.recent_audit_logs.map((entry) => ({
+                id: entry.id,
+                title: entry.action,
+                detail: `${entry.actor_type} -> ${entry.target_type}${entry.target_id ? ` (${entry.target_id})` : ""}`,
+                timestamp: entry.created_at,
+              }))}
+            />
+          </div>
         </>
       ) : null}
     </div>
@@ -498,6 +521,15 @@ function SnapshotRow({ label, value }: { label: string; value: string }) {
   );
 }
 
+function formatTimestamp(timestamp: string) {
+  return new Date(timestamp).toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
 function ActivityCard({
   title,
   items,
@@ -534,6 +566,48 @@ function ActivityCard({
               >
                 {item.actionLabel}
               </Button>
+            </div>
+          ))
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function RecentEventsCard({
+  title,
+  emptyLabel,
+  items,
+}: {
+  title: string;
+  emptyLabel: string;
+  items: Array<{
+    id: string;
+    title: string;
+    detail: string;
+    timestamp: string;
+  }>;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {items.length === 0 ? (
+          <p className="text-sm text-muted-foreground">{emptyLabel}</p>
+        ) : (
+          items.map((item) => (
+            <div key={item.id} className="rounded-lg border p-4">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <p className="font-medium">{item.title}</p>
+                  <p className="mt-1 text-sm text-muted-foreground">{item.detail}</p>
+                </div>
+                <span className="shrink-0 text-xs text-muted-foreground">
+                  {formatTimestamp(item.timestamp)}
+                </span>
+              </div>
             </div>
           ))
         )}


### PR DESCRIPTION
## What
- show recent support billing activity in the internal support console
- extend the console test coverage around the new activity signal

## Why
- the bounded internal-support slice was finished locally and needed a clean GitHub handoff

## How
- add the new recent-activity view into the admin console component
- update the focused console test to prove the new behavior

## Testing
- `pnpm --dir apps/web test -- internal-support-console.test.tsx` ✅

## Risk / Notes
- the separate dependency PR lane is already merged and should stay separate from this product slice
