### PR TITLE
docs: add portfolio context recovery note

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,3 +46,44 @@
 ## Verification Contract
 - Canonical commands are in `.codex/verify.commands`.
 - Use `.codex/scripts/run_verify_commands.sh` for deterministic execution.
+
+<!-- portfolio-context:start -->
+# Portfolio Context
+
+## What This Project Is
+
+StatusPage.sh is a self-hostable status page platform with built-in HTTP, TCP, DNS, and ICMP monitoring. It combines a public status page, incident management, subscriber notifications, signed webhooks, and a standalone Rust monitor binary.
+
+## Current State
+
+The repo is active product work. The README frames the product as open-source self-hosted core plus managed paid beta. Current local changes touch PR-template metadata, so portfolio recovery should stay documentation-only.
+
+## Stack
+
+| Layer | Technology |
+|-------|------------|
+| Language | Rust (Axum 0.8) + TypeScript |
+| Frontend | Next.js 16 (App Router) + shadcn/ui + Tailwind CSS v4 |
+| Database | PostgreSQL 16 |
+| Monitor | Standalone Rust binary with cron scheduler |
+| Auth | Auth.js v5 + GitHub OAuth |
+| Monorepo | Turborepo + pnpm workspaces |
+
+## How To Run
+
+- Copy `.env.example` to `.env` and fill the GitHub OAuth and database settings.
+- Run the local stack with `docker compose up`.
+- Open `http://localhost:3000`; the monitor binary starts automatically and begins health checks on configured services.
+
+## Known Risks
+
+- Monitor checks and incident updates write operational state into Postgres; avoid destructive database resets unless explicitly requested.
+- Webhook delivery uses HMAC signatures and retry behavior; preserve signature verification when changing delivery code.
+- Auth depends on GitHub OAuth; do not commit OAuth secrets or local `.env` values.
+- Keep PR-template drift separate from product/runtime changes.
+
+## Next Recommended Move
+
+Resolve the existing PR-template drift separately, then verify the monitor, incident, subscriber, and webhook paths before changing runtime behavior.
+
+<!-- portfolio-context:end -->


### PR DESCRIPTION
## What

Adds a managed portfolio-context block to AGENTS.md.

## Why

This closes one dirty-worktree item in the GithubRepoAuditor context recovery plan while leaving unrelated local PR-template work untouched.

## How

Documentation-only update based on the README and repo-local guidance.

## Checklist

- [x] Tests pass
- [x] No new warnings
- [x] Documentation updated (if applicable)

## Testing

- `git diff --check`
- Placeholder scan for generic filler